### PR TITLE
Rename blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,27 +89,27 @@ WARNING: Invoking this command will pull ~10GB and take at least an hour
 
 ## More Details
 
-### blacklist/whitelist configuration
+### denylist/allowlist configuration
 
 example-conf.yaml:
 
 ```yaml
-blacklist:
+denylist:
     - license: "*agpl*"
     - license: None
     - license: ""
 
-whitelist:
+allowlist:
     - name: system
 ```
 
-`blacklist` removes package(s) that match the condition(s) listed from the
+`denylist` removes package(s) that match the condition(s) listed from the
 upstream repodata.
 
-`whitelist` re-includes any package(s) from blacklist that match the
-whitelist conditions.
+`allowlist` re-includes any package(s) from denylist that match the
+allowlist conditions.
 
-blacklist and whitelist both take lists of dictionaries. The keys in the
+denylist and allowlist both take lists of dictionaries. The keys in the
 dictionary need to be values in the `repodata.json` metadata. The values are
 (unix) globs to match on. Go here for the full repodata of the upstream
 "defaults" channel:
@@ -144,28 +144,28 @@ information.
 #### Common usage patterns
 ##### Mirror **only** one specific package
 If you wanted to match exactly the botocore package listed above with your
-config, then you could use the following configuration to first blacklist
+config, then you could use the following configuration to first denylist
 **all** packages and then include just the botocore packages:
 
 ```yaml
-blacklist:
+denylist:
     - name: "*"
-whitelist:
+allowlist:
     - name: botocore
       version: 1.4.10
       build: py34_0
 ```
 ##### Mirror everything but agpl licenses
 ```yaml
-blacklist:
+denylist:
     - license: "*agpl*"
 ```
 
 ##### Mirror only python 3 packages
 ```yaml
-blacklist:
+denylist:
     - name: "*"
-whitelist:
+allowlist:
     - build: "*py3*"
 ```
 

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -305,15 +305,23 @@ def _parse_and_format_args():
     allowlist = config_dict.get('allowlist')
     if blacklist and denylist:
         # Would be odd to be here, but might as well be nice to the users
-        logger.warning("Please remove blacklist from your config. This will stop working in the next minor release")
+        logger.warning(
+            "Please remove blacklist from your config. "
+            "This will stop working in the next minor release")
     if whitelist and allowlist:
         # Would be odd to be here, but might as well be nice to the users
-        logger.warning("Please remove whitelist from your config. This will stop working in the next minor release")
+        logger.warning(
+            "Please remove whitelist from your config. "
+            "This will stop working in the next minor release")
     if blacklist and not denylist:
-        logger.warning("Please rename blacklist to denylist in your config. This will stop working in the next minor release")
+        logger.warning(
+            "Please rename blacklist to denylist in your config. "
+            "This will stop working in the next minor release")
         denylist = blacklist
     if whitelist and not allowlist:
-        logger.warning("Please rename whitelist to allowlist in your config. This will stop working in the next minor release")
+        logger.warning(
+            "Please rename whitelist to allowlist in your config. "
+            "This will stop working in the next minor release")
         allowlist = whitelist
 
     del blacklist

--- a/example-conf.yaml
+++ b/example-conf.yaml
@@ -1,7 +1,7 @@
-blacklist:
+denylist:
     - license: "*agpl*"
     - license: None
     - license: ""
     - name: "*"
-whitelist:
+allowlist:
     - name: system

--- a/test/test_conda_mirror.py
+++ b/test/test_conda_mirror.py
@@ -60,9 +60,9 @@ def test_cli(tmpdir, channel, platform, repodata, num_threads):
     f1 = tmpdir.mkdir('conf').join('conf.yaml')
 
     f1.write('''
-blacklist:
+denylist:
     - name: "*"
-whitelist:
+allowlist:
     - name: {}
       version: {}'''.format(packages[smallest_package]['name'],
                             packages[smallest_package]['version']))
@@ -138,8 +138,8 @@ def test_main(tmpdir, repodata):
         target_directory=target_directory.strpath,
         temp_directory=temp_directory.strpath,
         platform=platform,
-        blacklist=[{'name': '*'}],
-        whitelist=[{'name': packages[smallest_package]['name'],
+        denylist=[{'name': '*'}],
+        allowlist=[{'name': packages[smallest_package]['name'],
                     'version': packages[smallest_package]['version']}])
 
     assert len(ret['validating-existing']) == 0, "There should be no already-downloaded packages"
@@ -152,8 +152,8 @@ def test_main(tmpdir, repodata):
         target_directory=target_directory.strpath,
         temp_directory=temp_directory.strpath,
         platform=platform,
-        blacklist=[{'name': '*'}],
-        whitelist=[{'name': packages[next_smallest_package]['name'],
+        denylist=[{'name': '*'}],
+        allowlist=[{'name': packages[next_smallest_package]['name'],
                     'version': packages[next_smallest_package]['version']}])
 
     msg = "We should have %s packages downloaded now" % previously_downloaded_packages


### PR DESCRIPTION
Language matters.
https://twitter.com/leahculver/status/1269109776983547904
https://twitter.com/alessandramakes/status/1269116696834437121

I'd also be in ok with any of these *-list prefixes:
- go / green / nice / safe
- stop / red / naughty

This introduces a rename of blacklist -> denylist and whitelist -> allowlist. Backwards compatibility is enabled until such a time as we want to get rid of the backwards compat layer. In the warning message it says "until the next minor release", but that's sort of up to you all since you own the fork now. 