### PR TITLE
Switch to using yaml.safe_load to avoid Deprecation warnings.

### DIFF
--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -286,7 +286,7 @@ def _parse_and_format_args():
     if args.config:
         logger.info("Loading config from %s", args.config)
         with open(args.config, "r") as f:
-            config_dict = yaml.load(f)
+            config_dict = yaml.safe_load(f)
         logger.info("config: %s", config_dict)
 
         # use values from config file unless explicitly given on command line


### PR DESCRIPTION
Since pyyaml version 5.1, using `yaml.load(myfile)` directly is deprecated and prints an annoying warning message. Switching over to using `yaml.safe_load(myfile)` will not trigger the deprecation warning and will also be backwards compatible as the safe_load method has existed for sometime. Safe loading will only load a subset of yaml, but since the only use here is to load a dict, it is sufficient.

An alternate approach would be to explicitly specify the loader via `yaml.load(myfile, Loader=yaml.FullLoader)`, but that is not backwards compatible.

No new tests need to be added.