### PR TITLE
Add optional targets for reference.json and update.tar to conda-diff-tar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ cover/
 nosetests.xml
 coverage.xml
 
+# Possible files generated during tests
+reference.json
+update.tar
+
 # Translations
 *.mo
 *.pot
@@ -70,6 +74,9 @@ docs/_build/
 
 #pycharm
 .idea/*
+
+#vscode
+.vscode
 
 #Dolphin browser files
 .directory/

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -373,7 +373,11 @@ def _remove_package(pkg_path, reason):
         The reason why the package is being removed
     """
     msg = "Removing: %s. Reason: %s" % (pkg_path, reason)
-    logger.warning(msg)
+    if logger:
+        logger.warning(msg)
+    else:
+        # Logging breaks in multiprocessing in Windows
+        sys.stdout.write("Warning: " + msg)
     os.remove(pkg_path)
     return pkg_path, msg
 
@@ -656,13 +660,23 @@ def _validate_or_remove_package(args):
     try:
         package_metadata = package_repodata[package]
     except KeyError:
-        logger.warning("%s is not in the upstream index. Removing...", package)
+        log_msg = f"{package} is not in the upstream index. Removing..."
+        if logger:
+            logger.warning(log_msg)
+        else:
+            # Windows does not handle multiprocessing logging well
+            sys.stdout.write("Warning: " + log_msg)
         reason = "Package is not in the repodata index"
         package_path = os.path.join(package_directory, package)
         return _remove_package(package_path, reason=reason)
     # validate the integrity of the package, the size of the package and
     # its hashes
-    logger.info("Validating {:4d} of {:4d}: {}.".format(num + 1, num_packages, package))
+    log_msg = "Validating {:4d} of {:4d}: {}.".format(num + 1, num_packages, package)
+    if logger:
+        logger.info(log_msg)
+    else:
+        # Windows does not handle multiprocessing logging well
+        sys.stdout.write("Info: "+log_msg)
     package_path = os.path.join(package_directory, package)
     return _validate(
         package_path, md5=package_metadata.get("md5"), size=package_metadata.get("size")

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -377,6 +377,7 @@ def _remove_package(pkg_path, reason):
         logger.warning(msg)
     else:
         # Logging breaks in multiprocessing in Windows
+        # TODO: Fix this properly with a logging Queue
         sys.stdout.write("Warning: " + msg)
     os.remove(pkg_path)
     return pkg_path, msg
@@ -665,6 +666,7 @@ def _validate_or_remove_package(args):
             logger.warning(log_msg)
         else:
             # Windows does not handle multiprocessing logging well
+            # TODO: Fix this properly with a logging Queue
             sys.stdout.write("Warning: " + log_msg)
         reason = "Package is not in the repodata index"
         package_path = os.path.join(package_directory, package)
@@ -676,6 +678,7 @@ def _validate_or_remove_package(args):
         logger.info(log_msg)
     else:
         # Windows does not handle multiprocessing logging well
+        # TODO: Fix this properly with a logging Queue
         sys.stdout.write("Info: "+log_msg)
     package_path = os.path.join(package_directory, package)
     return _validate(

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -179,7 +179,7 @@ def main():
         "-i",
         "--infile",
         action="store",
-        help="Path to specify references json file when using --create"
+        help="Path to specify references json file when using --create or --show"
     )
 
     p.add_argument(

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -73,11 +73,13 @@ def verify_all_repos(mirror_dir):
             print("MD5 mismatch: %s" % path)
 
 
-def write_reference(mirror_dir, outfile=DEFAULT_REFERENCE_PATH):
+def write_reference(mirror_dir, outfile=None):
     """
     Write the "reference file", which is a collection of the content of all
     repodata.json files.
     """
+    if not outfile:
+        outfile = DEFAULT_REFERENCE_PATH
     data = json.dumps(all_repodata(mirror_dir), indent=2, sort_keys=True)
     # make sure we have newline at the end
     if not data.endswith("\n"):
@@ -86,10 +88,12 @@ def write_reference(mirror_dir, outfile=DEFAULT_REFERENCE_PATH):
         fo.write(data)
 
 
-def read_reference(infile=DEFAULT_REFERENCE_PATH):
+def read_reference(infile=None):
     """
     Read the "reference file" from disk and return its content as a dictionary.
     """
+    if not infile:
+        infile = DEFAULT_REFERENCE_PATH
     try:
         with open(infile) as fi:
             return json.load(fi)
@@ -97,13 +101,15 @@ def read_reference(infile=DEFAULT_REFERENCE_PATH):
         raise NoReferenceError(e)
 
 
-def get_updates(mirror_dir, infile=DEFAULT_REFERENCE_PATH):
+def get_updates(mirror_dir, infile=None):
     """
     Compare the "reference file" to the actual the repository (all the
     repodata.json files) and iterate the new and updates files in the
     repository.  That is, the files which need to go into the differential
     tarball.
     """
+    if not infile:
+        infile = DEFAULT_REFERENCE_PATH
     d1 = read_reference(infile)
     d2 = all_repodata(mirror_dir)
     for repo_path, index2 in d2.items():
@@ -119,13 +125,17 @@ def get_updates(mirror_dir, infile=DEFAULT_REFERENCE_PATH):
 
 def tar_repo(
     mirror_dir,
-    infile=DEFAULT_REFERENCE_PATH,
-    outfile=DEFAULT_UPDATE_PATH,
+    infile=None,
+    outfile=None,
     verbose=False
 ):
     """
     Write the so-called differential tarball, see get_updates().
     """
+    if not infile:
+        infile = DEFAULT_REFERENCE_PATH
+    if not outfile:
+        outfile = DEFAULT_UPDATE_PATH
     t = tarfile.open(outfile, "w")
     for f in get_updates(mirror_dir, infile):
         if verbose:

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -231,7 +231,15 @@ def main():
             verify_all_repos(mirror_dir)
 
         elif args.show:
-            for path in get_updates(mirror_dir):
+            if args.infile:
+                infile = args.infile
+            else:
+                infile = DEFAULT_REFERENCE_PATH
+
+            if args.outfile:
+                p.error("--outfile not allowed with --show")
+
+            for path in get_updates(mirror_dir, infile):
                 print(path)
 
         elif args.reference:

--- a/diff-tar.md
+++ b/diff-tar.md
@@ -4,24 +4,59 @@ Create differential tarballs
 This tools allows you to create differential tarballs of a (usually
 mirrored) conda repository.  The resulting tarball can be used to update
 a copy of the mirror on a remote (air-gapped) system, without having to
-copy the entire conda repository.  The workflow is a follows:
+copy the entire conda repository.
+
+Usage:
+------
+Running `conda-diff-tar --help` will show the following output:
+
+```
+usage: conda-diff-tar [-h] [--create] [--reference] [-o OUTFILE] [-i INFILE]
+                      [--show] [--verify] [-v] [--version]
+                      [REPOSITORY]
+
+create "differential" tarballs of a conda repository
+
+positional arguments:
+  REPOSITORY            path to repository directory
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --create              create differential tarball
+  --reference           create a reference point file
+  -o OUTFILE, --outfile OUTFILE
+                        Path to references json file when using --reference,
+                        or update tarfile when using --create
+  -i INFILE, --infile INFILE
+                        Path to specify references json file when using
+                        --create or --show
+  --show                show the files in respect to the latest reference
+                        point file (which would be included in the
+                        differential tarball)
+  --verify              verify the mirror repository and exit
+  -v, --verbose
+  --version             print version and exit
+```
+
+Example workflow:
+-----------------
 
   1. we assume that the remote and local repository are in sync
-  2. create a `reference.json` file of the local repository
+  2. create a `reference.json` file of the local repository with the `--reference` flag
   3. update the local repository using `conda-mirror` or some other tools
-  4. create the "differential" tarball
+  4. create the "differential" tarball with the `--create` flag
   5. move the differential tarball to the remote machine, and unpack it
   6. now that the remote repository is up-to-date, we should create a new
-     `reference.json` on the local machine.  That is, step 2
+     `reference.json` on the local machine.  That is, repeat step 2
 
 
 Notes:
 ------
 
-The file `reference.json` is a collection of all `repodata.json`
-files (`linux-64`, `win-32`, `noarch`, etc.) of the local repository.
+The file `reference.json` (or whatever you named it) is a collection of all `repodata.json`
+files (`linux-64`, `win-32`, `noarch`, etc.) in the local repository.
 It is created in order to compare a future state of the repository to the
-state of the repository when `reference.json` it was created.
+state of the repository when `reference.json` was created.
 
 The differential tarball contains files which either have been updated (such
 as `repodata.json`) or new files (new conda packages).  It is meant to be
@@ -31,7 +66,6 @@ unpacked on top of the existing mirror on the remote machine by:
     tar xf update.tar
     # or y using tar's -C option from any directory
     tar xf update.tar -C <repository>
-
 
 Example:
 --------

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -139,10 +139,55 @@ def test_version():
     run_with_args(["--version"])
 
 
-def test_misc(tmpdir):
+def test_cli_reference(tmpdir):
     create_test_repo()
     run_with_args(["--reference", dt.mirror_dir])
     assert isfile(dt.DEFAULT_REFERENCE_PATH)
+
+
+def test_cli_reference_outfile(tmpdir):
+    target_path = join(tmpdir, "ref_target.json")
+    create_test_repo()
+    run_with_args(["--reference", dt.mirror_dir])
+    assert isfile(dt.DEFAULT_REFERENCE_PATH)
+    run_with_args(["--reference", "--outfile", target_path, dt.mirror_dir])
+    assert isfile(target_path)
+    with open(dt.DEFAULT_REFERENCE_PATH, 'r') as ref1:
+        with open(target_path, 'r') as ref2:
+            assert ref1.readlines() == ref2.readlines()
+
+
+def test_cli_create_outfile(tmpdir):
+    target_path = join(tmpdir, "tar_target.tar")
+    create_test_repo()
+    run_with_args(["--reference", dt.mirror_dir])
+    run_with_args(["--create", "--outfile", target_path, dt.mirror_dir])
+    assert isfile(target_path)
+
+
+def test_cli_create_infile(tmpdir):
+    target_ref_path = join(tmpdir, "ref_target.json")
+    create_test_repo()
+    run_with_args(["--reference", "--outfile", target_ref_path, dt.mirror_dir])
+    assert isfile(target_ref_path)
+    run_with_args(["--create", "--infile", target_ref_path, dt.mirror_dir])
+    assert isfile(dt.DEFAULT_UPDATE_PATH)
+
+
+def test_cli_create_infile_outfile(tmpdir):
+    target_tar_path = join(tmpdir, "tar_target.tar")
+    target_ref_path = join(tmpdir, "ref_target.json")
+    create_test_repo()
+    run_with_args(["--reference", "--outfile", target_ref_path, dt.mirror_dir])
+    assert isfile(target_ref_path)
+    run_with_args(["--create", "--outfile", target_tar_path,
+                   "--infile", target_ref_path, dt.mirror_dir])
+    assert isfile(target_tar_path)
+
+
+def test_misc(tmpdir):
+    create_test_repo()
+    run_with_args(["--reference", dt.mirror_dir])
     create_test_repo("win-32")
     run_with_args(["--show", dt.mirror_dir])
     run_with_args(["--create", "--verbose", dt.mirror_dir])

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -18,7 +18,8 @@ EMPTY_MD5 = "d41d8cd98f00b204e9800998ecf8427e"
 def tmpdir():
     tmpdir = tempfile.mkdtemp()
     dt.mirror_dir = join(tmpdir, "repo")
-    dt.REFERENCE_PATH = join(tmpdir, "reference.json")
+    dt.DEFAULT_REFERENCE_PATH = join(tmpdir, "reference.json")
+    dt.DEFAULT_UPDATE_PATH = join(tmpdir, "updates.tar")
     yield tmpdir
     shutil.rmtree(tmpdir)
 
@@ -71,8 +72,8 @@ def test_write_and_read_reference(tmpdir):
 
 def test_write_and_read_reference_with_target(tmpdir):
     create_test_repo()
-    dt.write_reference(join(tmpdir, "repo"), join(tmpdir, "reference2.json"))
-    ref = dt.read_reference(join(tmpdir, "reference2.json"))
+    dt.write_reference(join(tmpdir, "repo"), join(tmpdir, "reference_target.json"))
+    ref = dt.read_reference(join(tmpdir, "reference_target.json"))
     assert ref[join(dt.mirror_dir, "linux-64")]["a-1.0-0.tar.bz2"]["md5"] == EMPTY_MD5
 
 
@@ -94,8 +95,8 @@ def test_get_updates(tmpdir):
 
 def test_get_updates_with_target(tmpdir):
     create_test_repo()
-    dt.write_reference(join(tmpdir, "repo"), join(tmpdir, "reference2.json"))
-    assert list(dt.get_updates(dt.mirror_dir, join(tmpdir, "reference2.json"))) == []
+    dt.write_reference(join(tmpdir, "repo"), join(tmpdir, "reference_target.json"))
+    assert list(dt.get_updates(dt.mirror_dir, join(tmpdir, "reference_target.json"))) == []
 
     create_test_repo("win-32")
     lst = sorted(
@@ -111,19 +112,19 @@ def test_get_updates_with_target(tmpdir):
 
 def test_tar_repo(tmpdir):
     create_test_repo()
-    tarball = join(tmpdir, "up.tar")
     dt.write_reference(dt.mirror_dir)
     create_test_repo("win-32")
-    dt.tar_repo(dt.mirror_dir, tarball)
-    assert isfile(tarball)
+    dt.tar_repo(dt.mirror_dir)
+    assert isfile(dt.DEFAULT_UPDATE_PATH)
 
 
 def test_tar_repo_with_target(tmpdir):
     create_test_repo()
-    tarball = join(tmpdir, "up.tar")
-    dt.write_reference(dt.mirror_dir, join(tmpdir, "reference2.json"))
+    tarball = join(tmpdir, "updates_target.tar")
+    reference = join(tmpdir, "reference_target.json")
+    dt.write_reference(dt.mirror_dir, reference)
     create_test_repo("win-32")
-    dt.tar_repo(dt.mirror_dir, join(tmpdir, "reference2.json"), tarball)
+    dt.tar_repo(dt.mirror_dir, reference, tarball)
     assert isfile(tarball)
 
 
@@ -141,7 +142,7 @@ def test_version():
 def test_misc(tmpdir):
     create_test_repo()
     run_with_args(["--reference", dt.mirror_dir])
-    assert isfile(dt.REFERENCE_PATH)
+    assert isfile(dt.DEFAULT_REFERENCE_PATH)
     create_test_repo("win-32")
     run_with_args(["--show", dt.mirror_dir])
     run_with_args(["--create", "--verbose", dt.mirror_dir])

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -4,6 +4,7 @@ import json
 import shutil
 import tempfile
 from os.path import isfile, join
+import pathlib
 
 import pytest
 
@@ -81,11 +82,13 @@ def test_get_updates(tmpdir):
     assert list(dt.get_updates(dt.mirror_dir)) == []
 
     create_test_repo("win-32")
-    lst = sorted(dt.get_updates(dt.mirror_dir))
+    lst = sorted(
+        pathlib.Path(f) for f in dt.get_updates(dt.mirror_dir)
+    )
     assert lst == [
-        "win-32/a-1.0-0.tar.bz2",
-        "win-32/repodata.json",
-        "win-32/repodata.json.bz2",
+        pathlib.Path("win-32/a-1.0-0.tar.bz2"),
+        pathlib.Path("win-32/repodata.json"),
+        pathlib.Path("win-32/repodata.json.bz2"),
     ]
 
 
@@ -95,11 +98,14 @@ def test_get_updates_with_target(tmpdir):
     assert list(dt.get_updates(dt.mirror_dir, join(tmpdir, "reference2.json"))) == []
 
     create_test_repo("win-32")
-    lst = sorted(dt.get_updates(dt.mirror_dir, join(tmpdir, "reference2.json")))
+    lst = sorted(
+        pathlib.Path(f)
+        for f in dt.get_updates(dt.mirror_dir, join(tmpdir, "reference_target.json"))
+    )
     assert lst == [
-        "win-32/a-1.0-0.tar.bz2",
-        "win-32/repodata.json",
-        "win-32/repodata.json.bz2",
+        pathlib.Path("win-32/a-1.0-0.tar.bz2"),
+        pathlib.Path("win-32/repodata.json"),
+        pathlib.Path("win-32/repodata.json.bz2"),
     ]
 
 

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -68,6 +68,13 @@ def test_write_and_read_reference(tmpdir):
     assert ref[join(dt.mirror_dir, "linux-64")]["a-1.0-0.tar.bz2"]["md5"] == EMPTY_MD5
 
 
+def test_write_and_read_reference_with_target(tmpdir):
+    create_test_repo()
+    dt.write_reference(join(tmpdir, "repo"), join(tmpdir, "reference2.json"))
+    ref = dt.read_reference(join(tmpdir, "reference2.json"))
+    assert ref[join(dt.mirror_dir, "linux-64")]["a-1.0-0.tar.bz2"]["md5"] == EMPTY_MD5
+
+
 def test_get_updates(tmpdir):
     create_test_repo()
     dt.write_reference(join(tmpdir, "repo"))
@@ -82,12 +89,35 @@ def test_get_updates(tmpdir):
     ]
 
 
+def test_get_updates_with_target(tmpdir):
+    create_test_repo()
+    dt.write_reference(join(tmpdir, "repo"), join(tmpdir, "reference2.json"))
+    assert list(dt.get_updates(dt.mirror_dir, join(tmpdir, "reference2.json"))) == []
+
+    create_test_repo("win-32")
+    lst = sorted(dt.get_updates(dt.mirror_dir, join(tmpdir, "reference2.json")))
+    assert lst == [
+        "win-32/a-1.0-0.tar.bz2",
+        "win-32/repodata.json",
+        "win-32/repodata.json.bz2",
+    ]
+
+
 def test_tar_repo(tmpdir):
     create_test_repo()
     tarball = join(tmpdir, "up.tar")
     dt.write_reference(dt.mirror_dir)
     create_test_repo("win-32")
     dt.tar_repo(dt.mirror_dir, tarball)
+    assert isfile(tarball)
+
+
+def test_tar_repo_with_target(tmpdir):
+    create_test_repo()
+    tarball = join(tmpdir, "up.tar")
+    dt.write_reference(dt.mirror_dir, join(tmpdir, "reference2.json"))
+    create_test_repo("win-32")
+    dt.tar_repo(dt.mirror_dir, join(tmpdir, "reference2.json"), tarball)
     assert isfile(tarball)
 
 


### PR DESCRIPTION
This PR adds a feature to diff_tar.py wherein the user can now specify `--infile` and/or `--outfile` arguments to the conda-diff-tar script in order to specify where files should read/write from/to. Behavior is:

- With `--create`, infile refers to the reference.json file, outfile refers to the update.tar file.
- With `--reference`, infile is not accepted, outfile refers to the reference.json file.
- With `--show`, infile refers to the references.json file, outfile is not accepted.

This PR adds unit tests for the above.

This PR also adds Windows compatibility to all the tests. I tried to keep these fixes in their own commits for the most part to make cherry-picking easier if this is  not a desired feature.

This PR closes #19 and also #17.

There is still a little work to do surrounding updating the changelog to reflect the new feature and potentially assigning a new minor version number. I'm not quite sure what the right format is, and was hoping to get some pointers from the maintainers for what changes would need to be added to merge this new feature in. 