### PR TITLE
Use requests.Session to improve download speed (issue #28)

### DIFF
--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -731,7 +731,7 @@ def main(
     minimum_free_space=0,
     proxies=None,
     ssl_verify=None,
-    chunk_size:int=DEFAULT_CHUNK_SIZE,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
     max_retries=100,
 ):
     """

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -24,6 +24,8 @@ DEFAULT_BAD_LICENSES = ["agpl", ""]
 
 DEFAULT_PLATFORMS = ["linux-64", "linux-32", "osx-64", "win-64", "win-32"]
 
+DEFAULT_CHUNK_SIZE = 16 * 1024
+
 
 def _maybe_split_channel(channel):
     """Split channel if it is fully qualified.
@@ -130,7 +132,8 @@ def _make_arg_parser():
         ),
     )
     ap.add_argument(
-        "--target-directory", help="The place where packages should be mirrored to",
+        "--target-directory",
+        help="The place where packages should be mirrored to",
     )
     ap.add_argument(
         "--temp-directory",
@@ -160,7 +163,9 @@ def _make_arg_parser():
         default=0,
     )
     ap.add_argument(
-        "--config", action="store", help="Path to the yaml config file",
+        "--config",
+        action="store",
+        help="Path to the yaml config file",
     )
     ap.add_argument(
         "--pdb",
@@ -176,7 +181,10 @@ def _make_arg_parser():
         help="Num of threads for validation. 1: Serial mode. 0: All available.",
     )
     ap.add_argument(
-        "--version", action="store_true", help="Print version and quit", default=False,
+        "--version",
+        action="store_true",
+        help="Print version and quit",
+        default=False,
     )
     ap.add_argument(
         "--dry-run",
@@ -351,8 +359,7 @@ def _parse_and_format_args():
 
 
 def cli():
-    """Thin wrapper around parsing the cli args and calling main with them
-    """
+    """Thin wrapper around parsing the cli args and calling main with them"""
     main(**_parse_and_format_args())
 
 
@@ -471,7 +478,15 @@ def get_repodata(channel, platform, proxies=None, ssl_verify=None):
     return info, packages
 
 
-def _download(url, target_directory, proxies=None, ssl_verify=None):
+def _download(
+    url,
+    target_directory,
+    session: requests.Session,
+    *,
+    proxies=None,
+    ssl_verify=None,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+):
     """Download `url` to `target_directory`
 
     Parameters
@@ -480,6 +495,8 @@ def _download(url, target_directory, proxies=None, ssl_verify=None):
         The url to download
     target_directory : str
         The path to a directory where `url` should be downloaded
+    session: requests.Session
+        HTTP session instance.
     proxies : dict
         Proxys for connecting internet
     ssl_verify : str or bool
@@ -491,14 +508,13 @@ def _download(url, target_directory, proxies=None, ssl_verify=None):
         The size in bytes of the file that was downloaded
     """
     file_size = 0
-    chunk_size = 1024  # 1KB chunks
     logger.info("download_url=%s", url)
     # create a temporary file
     target_filename = url.split("/")[-1]
     download_filename = os.path.join(target_directory, target_filename)
     logger.debug("downloading to %s", download_filename)
     with open(download_filename, "w+b") as tf:
-        ret = requests.get(url, stream=True, proxies=proxies, verify=ssl_verify)
+        ret = session.get(url, stream=True, proxies=proxies, verify=ssl_verify)
         for data in ret.iter_content(chunk_size):
             tf.write(data)
         file_size = os.path.getsize(download_filename)
@@ -506,7 +522,14 @@ def _download(url, target_directory, proxies=None, ssl_verify=None):
 
 
 def _download_backoff_retry(
-    url, target_directory, proxies=None, ssl_verify=None, max_retries=100
+    url,
+    target_directory,
+    session: requests.Session,
+    *,
+    proxies=None,
+    ssl_verify=None,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    max_retries: int = 100,
 ):
     """Download `url` to `target_directory` with exponential backoff in the
     event of failure.
@@ -517,10 +540,14 @@ def _download_backoff_retry(
         The url to download
     target_directory : str
         The path to a directory where `url` should be downloaded
+    session: requests.Session
+        HTTP session instance.
     proxies : dict
         Proxys for connecting internet
     ssl_verify : str or bool
         Path to a CA_BUNDLE file or directory with certificates of trusted CAs
+    chunk_size: int
+        Size of contiguous chunk to download in bytes.
     max_retries : int, optional
         The maximum number of times to retry before the download error is reraised,
         default 100.
@@ -538,7 +565,12 @@ def _download_backoff_retry(
         two_c *= 2
         try:
             rtn = _download(
-                url, target_directory, proxies=proxies, ssl_verify=ssl_verify
+                url,
+                target_directory,
+                session,
+                proxies=proxies,
+                ssl_verify=ssl_verify,
+                chunk_size=chunk_size,
             )
             break
         except Exception:
@@ -679,7 +711,7 @@ def _validate_or_remove_package(args):
     else:
         # Windows does not handle multiprocessing logging well
         # TODO: Fix this properly with a logging Queue
-        sys.stdout.write("Info: "+log_msg)
+        sys.stdout.write("Info: " + log_msg)
     package_path = os.path.join(package_directory, package)
     return _validate(
         package_path, md5=package_metadata.get("md5"), size=package_metadata.get("size")
@@ -699,6 +731,7 @@ def main(
     minimum_free_space=0,
     proxies=None,
     ssl_verify=None,
+    chunk_size:int=DEFAULT_CHUNK_SIZE,
     max_retries=100,
 ):
     """
@@ -746,6 +779,8 @@ def main(
         Proxys for connecting internet
     ssl_verify : str or bool
         Path to a CA_BUNDLE file or directory with certificates of trusted CAs
+    chunk_size: int
+        Size of chunks to download in bytes. Default is 1MB.
     max_retries : int, optional
         The maximum number of times to retry before the download error is reraised,
         default 100.
@@ -890,6 +925,7 @@ def main(
     total_bytes = 0
     minimum_free_space_kb = minimum_free_space * 1024 * 1024
     download_url, channel = _maybe_split_channel(upstream_channel)
+    session = requests.Session()
     with tempfile.TemporaryDirectory(dir=temp_directory) as download_dir:
         logger.info("downloading to the tempdir %s", download_dir)
         for package_name in sorted(to_mirror):
@@ -909,8 +945,10 @@ def main(
                 total_bytes += _download_backoff_retry(
                     url,
                     download_dir,
+                    session,
                     proxies=proxies,
                     ssl_verify=ssl_verify,
+                    chunk_size=chunk_size,
                     max_retries=max_retries,
                 )
 

--- a/conda_mirror/diff_tar.py
+++ b/conda_mirror/diff_tar.py
@@ -123,12 +123,7 @@ def get_updates(mirror_dir, infile=None):
                 yield relpath(join(repo_path, fn), mirror_dir)
 
 
-def tar_repo(
-    mirror_dir,
-    infile=None,
-    outfile=None,
-    verbose=False
-):
+def tar_repo(mirror_dir, infile=None, outfile=None, verbose=False):
     """
     Write the so-called differential tarball, see get_updates().
     """
@@ -179,7 +174,7 @@ def main():
         "-i",
         "--infile",
         action="store",
-        help="Path to specify references json file when using --create or --show"
+        help="Path to specify references json file when using --create or --show",
     )
 
     p.add_argument(

--- a/test/test_diff_tar.py
+++ b/test/test_diff_tar.py
@@ -83,9 +83,7 @@ def test_get_updates(tmpdir):
     assert list(dt.get_updates(dt.mirror_dir)) == []
 
     create_test_repo("win-32")
-    lst = sorted(
-        pathlib.Path(f) for f in dt.get_updates(dt.mirror_dir)
-    )
+    lst = sorted(pathlib.Path(f) for f in dt.get_updates(dt.mirror_dir))
     assert lst == [
         pathlib.Path("win-32/a-1.0-0.tar.bz2"),
         pathlib.Path("win-32/repodata.json"),
@@ -96,7 +94,9 @@ def test_get_updates(tmpdir):
 def test_get_updates_with_target(tmpdir):
     create_test_repo()
     dt.write_reference(join(tmpdir, "repo"), join(tmpdir, "reference_target.json"))
-    assert list(dt.get_updates(dt.mirror_dir, join(tmpdir, "reference_target.json"))) == []
+    assert (
+        list(dt.get_updates(dt.mirror_dir, join(tmpdir, "reference_target.json"))) == []
+    )
 
     create_test_repo("win-32")
     lst = sorted(
@@ -152,8 +152,8 @@ def test_cli_reference_outfile(tmpdir):
     assert isfile(dt.DEFAULT_REFERENCE_PATH)
     run_with_args(["--reference", "--outfile", target_path, dt.mirror_dir])
     assert isfile(target_path)
-    with open(dt.DEFAULT_REFERENCE_PATH, 'r') as ref1:
-        with open(target_path, 'r') as ref2:
+    with open(dt.DEFAULT_REFERENCE_PATH, "r") as ref1:
+        with open(target_path, "r") as ref2:
             assert ref1.readlines() == ref2.readlines()
 
 
@@ -180,8 +180,16 @@ def test_cli_create_infile_outfile(tmpdir):
     create_test_repo()
     run_with_args(["--reference", "--outfile", target_ref_path, dt.mirror_dir])
     assert isfile(target_ref_path)
-    run_with_args(["--create", "--outfile", target_tar_path,
-                   "--infile", target_ref_path, dt.mirror_dir])
+    run_with_args(
+        [
+            "--create",
+            "--outfile",
+            target_tar_path,
+            "--infile",
+            target_ref_path,
+            dt.mirror_dir,
+        ]
+    )
     assert isfile(target_tar_path)
 
 


### PR DESCRIPTION
Note that I added chunk_size arguments to the download functions but did not expose it at the command line since I did not find that there was really any benefit and did not want to present the user with a not very useful option.
