### PR TITLE
Add python_requires>=3.6 and a conda recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,40 @@
+# This recipe can be used to directly build a conda package for this project.
+# There is already a conda-forge feedstock for this project that pulls from pypi,
+# so this recipe is only needed if you want to build and deply a copy of this
+# package in your own channel.
+
+{% set data = load_setup_py_data() %} # copy parameters from setup.py
+
+package:
+  name: conda-mirror
+  version: {{ data['version'] }}
+
+source:
+  path: ..
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+  noarch: python
+
+requirements:
+  build:
+    - python {{ data['python_requires'] }}
+    - setuptools
+
+  run:
+    - python {{ data['python_requires'] }}
+
+    {% for dep in data['install_requires'] %}
+    - {{ dep.lower() }}
+    {% endfor %}
+
+test:
+  commands:
+    - conda-mirror -h
+
+about:
+  home: {{ data['url'] }}
+  license: {{ data['license'] }}
+  description: {{ data['description'] }}
+  summary: {{ data['description'] }}

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     platforms=["Linux", "Mac OSX", "Windows"],
     license="BSD 3-Clause",
     install_requires=["requests", "pyyaml", "tqdm"],
+    python_requires=">=3.6",
     entry_points={
         "console_scripts": [
             "conda-mirror = conda_mirror.conda_mirror:cli",


### PR DESCRIPTION
This adds a python_requires>=3.6 attribute to setup.py.

The code already assumes at least python 3.6, so we may just as well make it explicit in the package metadata.

The conda.recipe can be used to directly build a conda package that you can test locally or deploy to private channels.
