### PR TITLE
Add checkpointing and a "max packages to download" flag to CLI

### DIFF
--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -1122,13 +1122,14 @@ def main(
     session = requests.Session()
     with tempfile.TemporaryDirectory(dir=temp_directory) as download_dir:
         logger.info("downloading to the tempdir %s", download_dir)
-        for package_name in tqdm(
-            sorted(to_mirror),
-            desc=platform,
-            unit="package",
-            leave=False,
-            disable=not show_progress,
-        ):
+        for package_name, package_counter in enumerate(
+            tqdm(
+                sorted(to_mirror),
+                desc=platform,
+                unit="package",
+                leave=False,
+                disable=not show_progress,
+        )):
             url = download_url.format(
                 channel=channel, platform=platform, file_name=package_name
             )
@@ -1169,43 +1170,14 @@ def main(
                 logger.exception("Unexpected error: %s. Aborting download.", ex)
                 break
 
-        # validate all packages in the download directory
-        validation_results = _validate_packages(
-            packages, download_dir, num_threads=num_threads
-        )
-        summary["validating-new"].update(validation_results)
-        logger.debug(
-            "Newly downloaded files at %s are %s",
-            download_dir,
-            pformat(os.listdir(download_dir)),
-        )
-
-        # 8. Use already downloaded repodata.json contents but prune it of
-        # packages we don't want
-        repodata = {"info": info, "packages": packages}
-
-        # compute the packages that we have locally
-        packages_we_have = set(local_packages + _list_conda_packages(download_dir))
-        # remake the packages dictionary with only the packages we have
-        # locally
-        repodata["packages"] = {
-            name: info
-            for name, info in repodata["packages"].items()
-            if name in packages_we_have
-        }
-        _write_repodata(download_dir, repodata)
-
-        # move new conda packages
-        for f in _list_conda_packages(download_dir):
-            old_path = os.path.join(download_dir, f)
-            new_path = os.path.join(local_directory, f)
-            logger.info("moving %s to %s", old_path, new_path)
-            shutil.move(old_path, new_path)
-
-        for f in ("repodata.json", "repodata.json.bz2"):
-            download_path = os.path.join(download_dir, f)
-            move_path = os.path.join(local_directory, f)
-            shutil.move(download_path, move_path)
+            if (package_counter+1) % 100 == 0:
+                # Every 100 packages, pause to validate and move packages
+                # If we dont do this then whenever an invocation is interrupted, nothing is saved.
+                # This serves as basically a checkpoint
+                _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory)
+    
+    # When finished with the loop, validate and move the remaining packages
+    _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory)
 
     # Also need to make a "noarch" channel or conda gets mad
     noarch_path = os.path.join(target_directory, "noarch")
@@ -1215,6 +1187,45 @@ def main(
         _write_repodata(noarch_path, noarch_repodata)
 
     return summary
+
+def _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory):
+    # validate all packages in the download directory
+    validation_results = _validate_packages(
+        packages, download_dir, num_threads=num_threads
+    )
+    summary["validating-new"].update(validation_results)
+    logger.debug(
+        "Newly downloaded files at %s are %s",
+        download_dir,
+        pformat(os.listdir(download_dir)),
+    )
+
+    # 8. Use already downloaded repodata.json contents but prune it of
+    # packages we don't want
+    repodata = {"info": info, "packages": packages}
+
+    # compute the packages that we have locally
+    packages_we_have = set(local_packages + _list_conda_packages(download_dir))
+    # remake the packages dictionary with only the packages we have
+    # locally
+    repodata["packages"] = {
+        name: info
+        for name, info in repodata["packages"].items()
+        if name in packages_we_have
+    }
+    _write_repodata(download_dir, repodata)
+
+    # move new conda packages
+    for f in _list_conda_packages(download_dir):
+        old_path = os.path.join(download_dir, f)
+        new_path = os.path.join(local_directory, f)
+        logger.info("moving %s to %s", old_path, new_path)
+        shutil.move(old_path, new_path)
+
+    for f in ("repodata.json", "repodata.json.bz2"):
+        download_path = os.path.join(download_dir, f)
+        move_path = os.path.join(local_directory, f)
+        shutil.move(download_path, move_path)
 
 
 def _write_repodata(package_dir, repodata_dict):

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -1122,7 +1122,7 @@ def main(
     session = requests.Session()
     with tempfile.TemporaryDirectory(dir=temp_directory) as download_dir:
         logger.info("downloading to the tempdir %s", download_dir)
-        for package_name, package_counter in enumerate(
+        for package_counter, package_name in enumerate(
             tqdm(
                 sorted(to_mirror),
                 desc=platform,
@@ -1170,14 +1170,16 @@ def main(
                 logger.exception("Unexpected error: %s. Aborting download.", ex)
                 break
 
-            if (package_counter+1) % 100 == 0:
+            if (package_counter+1) % 15 == 0:
                 # Every 100 packages, pause to validate and move packages
                 # If we dont do this then whenever an invocation is interrupted, nothing is saved.
                 # This serves as basically a checkpoint
                 _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory)
+                # After moving packages to their ultimate resting place, update the packages we have locally
+                local_packages = _list_conda_packages(local_directory)
     
-    # When finished with the loop, validate and move the remaining packages
-    _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory)
+        # When finished with the loop, validate and move the remaining packages
+        _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory)
 
     # Also need to make a "noarch" channel or conda gets mad
     noarch_path = os.path.join(target_directory, "noarch")

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -623,7 +623,9 @@ def get_repodata(channel, platform, proxies=None, ssl_verify=None):
     try:
         resp.raise_for_status()
     except requests.exceptions.HTTPError:
-        raise RuntimeError(f"platform {platform} for channel {channel} not found on anaconda.org")
+        raise RuntimeError(
+            f"platform {platform} for channel {channel} not found on anaconda.org"
+        )
     resp = resp.json()
     info = resp.get("info", {})
     packages = resp.get("packages", {})
@@ -911,7 +913,7 @@ def main(
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     max_retries=100,
     show_progress: bool = True,
-    max_packages=None
+    max_packages=None,
 ):
     """
 
@@ -969,7 +971,7 @@ def main(
     show_progress: bool
         Show progress bar while downloading. True by default.
     max_packages : int, optional
-        Maximum number of packages to mirror. If not set, will mirror all packages 
+        Maximum number of packages to mirror. If not set, will mirror all packages
         in list
 
     Returns
@@ -1129,7 +1131,8 @@ def main(
                 unit="package",
                 leave=False,
                 disable=not show_progress,
-        )):
+            )
+        ):
             url = download_url.format(
                 channel=channel, platform=platform, file_name=package_name
             )
@@ -1170,16 +1173,32 @@ def main(
                 logger.exception("Unexpected error: %s. Aborting download.", ex)
                 break
 
-            if (package_counter+1) % 15 == 0:
+            if (package_counter + 1) % 15 == 0:
                 # Every 100 packages, pause to validate and move packages
                 # If we dont do this then whenever an invocation is interrupted, nothing is saved.
                 # This serves as basically a checkpoint
-                _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory)
+                _validate_and_move(
+                    packages,
+                    download_dir,
+                    num_threads,
+                    summary,
+                    info,
+                    local_packages,
+                    local_directory,
+                )
                 # After moving packages to their ultimate resting place, update the packages we have locally
                 local_packages = _list_conda_packages(local_directory)
-    
+
         # When finished with the loop, validate and move the remaining packages
-        _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory)
+        _validate_and_move(
+            packages,
+            download_dir,
+            num_threads,
+            summary,
+            info,
+            local_packages,
+            local_directory,
+        )
 
     # Also need to make a "noarch" channel or conda gets mad
     noarch_path = os.path.join(target_directory, "noarch")
@@ -1190,7 +1209,10 @@ def main(
 
     return summary
 
-def _validate_and_move(packages, download_dir, num_threads, summary, info, local_packages, local_directory):
+
+def _validate_and_move(
+    packages, download_dir, num_threads, summary, info, local_packages, local_directory
+):
     # validate all packages in the download directory
     validation_results = _validate_packages(
         packages, download_dir, num_threads=num_threads

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -1211,7 +1211,8 @@ def main(
                     local_packages,
                     local_directory,
                 )
-                # After moving packages to their ultimate resting place, update the packages we have locally
+                # After moving packages to their ultimate resting place,
+                # update the packages we have locally
                 local_packages = _list_conda_packages(local_directory)
 
         # When finished with the loop, validate and move the remaining packages


### PR DESCRIPTION
The current flow of conda-mirror is:

1. download _all_ the packages that are slated to be downloaded
2. validate the newly downloaded packages (md5, sha256, size, etc.)
3. then move them to the target local directory
4. update repodata.json

By checkpointing, I mean do steps 2, 3, 4 every N packages. In this case, I've hardcoded it to 25 (but that could easily be another configurable flag). The advantage of doing this is that it means that the mirror process can be interrupted pretty much at any point and you'll only lose, at most, 25 new packages that have been downloaded. As opposed to how this thing currently works where if the script is interrupted at _any_ point then _all_ of the packages will be deleted and you'll have to download them again.

I also added a `--max-packages` flag which can be useful for debugging