### PR TITLE
Option to only get n latest versions of matching packages #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   [\#22](https://github.com/conda-incubator/conda-mirror/issues/22)
 * Support use of conda package version specifiers
   [\#37](https://github.com/conda-incubator/conda-mirror/issues/37)
+* Options to only get n latest versions of matching packages. 
+  [\#52](https://github.com/conda-incubator/conda-mirror/issues/52)
 * Added tqdm based progress bars. 
   [\#29](https://github.com/conda-incubator/conda-mirror/issues/29)
 * Improve download speed, especially for smaller packages. 

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -23,7 +23,7 @@ import yaml
 from tqdm import tqdm
 
 try:
-    from conda.models.version import BuildNumberMatch, VersionSpec
+    from conda.models.version import BuildNumberMatch, VersionSpec, VersionOrder
 except ImportError:
     from .versionspec import BuildNumberMatch, VersionSpec, VersionOrder
 


### PR DESCRIPTION
Adds `--latest` and `--latest-dev` options to limit download to only the n most recent non-dev/dev versions of each package.