### PR TITLE
feat: Expose maximum parallelism and max-retries to configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,14 @@ pub struct CliConfig {
     #[arg(short, long)]
     pub config: Option<PathBuf>,
 
+    /// Maximum number of retires
+    #[arg(short = 'm', long, default_value_t = 10)]
+    pub max_retries: u8,
+    
+    /// Number of threads
+    #[arg(short = 't', long, default_value_t = 32)]
+    pub number_of_threads_per_subdir: u8,
+
     /// The S3 endpoint URL.
     #[arg(long, requires_all = ["s3_region_source", "s3_force_path_style_source"])]
     pub s3_endpoint_url_source: Option<Url>,
@@ -211,6 +219,9 @@ pub struct CondaMirrorYamlConfig {
     pub destination: Option<NamedChannelOrUrl>,
     pub subdirs: Option<Vec<Platform>>,
 
+    pub max_retries: Option<u8>,
+    pub number_of_threads_per_subdir: Option<u8>,
+
     pub include: Option<Vec<PackageConfig>>,
     pub exclude: Option<Vec<PackageConfig>>,
     pub s3_config: Option<S3ConfigSourceDest>,
@@ -237,6 +248,8 @@ pub struct CondaMirrorConfig {
     pub destination: NamedChannelOrUrl,
     pub subdirs: Option<Vec<Platform>>,
     pub mode: MirrorMode,
+    pub max_retries: u8,
+    pub number_of_threads_per_subdir: u8,
     pub s3_config_source: Option<S3Config>,
     pub s3_config_destination: Option<S3Config>,
     pub s3_credentials_source: Option<S3Credentials>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,10 +35,10 @@ pub struct CliConfig {
     /// Maximum number of retires
     #[arg(short = 'm', long, default_value_t = 10)]
     pub max_retries: u8,
-    
+
     /// Number of threads
     #[arg(short = 't', long, default_value_t = 32)]
-    pub number_of_threads_per_subdir: u8,
+    pub number_of_threads: u8,
 
     /// The S3 endpoint URL.
     #[arg(long, requires_all = ["s3_region_source", "s3_force_path_style_source"])]
@@ -220,7 +220,7 @@ pub struct CondaMirrorYamlConfig {
     pub subdirs: Option<Vec<Platform>>,
 
     pub max_retries: Option<u8>,
-    pub number_of_threads_per_subdir: Option<u8>,
+    pub number_of_threads: Option<u8>,
 
     pub include: Option<Vec<PackageConfig>>,
     pub exclude: Option<Vec<PackageConfig>>,
@@ -249,7 +249,7 @@ pub struct CondaMirrorConfig {
     pub subdirs: Option<Vec<Platform>>,
     pub mode: MirrorMode,
     pub max_retries: u8,
-    pub number_of_threads_per_subdir: u8,
+    pub number_of_threads: u8,
     pub s3_config_source: Option<S3Config>,
     pub s3_config_destination: Option<S3Config>,
     pub s3_credentials_source: Option<S3Credentials>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,13 +32,13 @@ pub struct CliConfig {
     #[arg(short, long)]
     pub config: Option<PathBuf>,
 
-    /// Maximum number of retires
-    #[arg(short = 'm', long, default_value_t = 10)]
+    /// Maximum number of retries.
+    #[arg(long, default_value_t = 10)]
     pub max_retries: u8,
 
-    /// Number of threads
-    #[arg(short = 't', long, default_value_t = 32)]
-    pub number_of_threads: u8,
+    /// Maximum number of concurrent connections.
+    #[arg(long, default_value_t = 32)]
+    pub max_parallel: u8,
 
     /// The S3 endpoint URL.
     #[arg(long, requires_all = ["s3_region_source", "s3_force_path_style_source"])]
@@ -220,7 +220,7 @@ pub struct CondaMirrorYamlConfig {
     pub subdirs: Option<Vec<Platform>>,
 
     pub max_retries: Option<u8>,
-    pub number_of_threads: Option<u8>,
+    pub max_parallel: Option<u8>,
 
     pub include: Option<Vec<PackageConfig>>,
     pub exclude: Option<Vec<PackageConfig>>,
@@ -249,7 +249,7 @@ pub struct CondaMirrorConfig {
     pub subdirs: Option<Vec<Platform>>,
     pub mode: MirrorMode,
     pub max_retries: u8,
-    pub number_of_threads: u8,
+    pub max_parallel: u8,
     pub s3_config_source: Option<S3Config>,
     pub s3_config_destination: Option<S3Config>,
     pub s3_credentials_source: Option<S3Credentials>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub async fn mirror(config: CondaMirrorConfig) -> miette::Result<()> {
     let subdirs = get_subdirs(&config, client.clone()).await?;
     tracing::info!("Mirroring the following subdirs: {:?}", subdirs);
 
-    let max_parallel = config.number_of_threads_per_subdir as usize;
+    let max_parallel = config.number_of_threads as usize;
     let multi_progress = Arc::new(MultiProgress::new());
     let semaphore = Arc::new(Semaphore::new(max_parallel));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub async fn mirror(config: CondaMirrorConfig) -> miette::Result<()> {
     let subdirs = get_subdirs(&config, client.clone()).await?;
     tracing::info!("Mirroring the following subdirs: {:?}", subdirs);
 
-    let max_parallel = 32;
+    let max_parallel = config.number_of_threads_per_subdir as usize;
     let multi_progress = Arc::new(MultiProgress::new());
     let semaphore = Arc::new(Semaphore::new(max_parallel));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub async fn mirror(config: CondaMirrorConfig) -> miette::Result<()> {
     let subdirs = get_subdirs(&config, client.clone()).await?;
     tracing::info!("Mirroring the following subdirs: {:?}", subdirs);
 
-    let max_parallel = config.number_of_threads as usize;
+    let max_parallel = config.max_parallel as usize;
     let multi_progress = Arc::new(MultiProgress::new());
     let semaphore = Arc::new(Semaphore::new(max_parallel));
 
@@ -451,7 +451,7 @@ async fn mirror_subdir<T: Configurator>(
     let builder = opendal_config.into_builder();
     let op = Operator::new(builder)
         .into_diagnostic()?
-        .layer(RetryLayer::new())
+        .layer(RetryLayer::new().with_max_times(config.max_retries.into()))
         .finish();
     let available_packages = op
         .list_with(&format!("{}/", subdir.as_str()))
@@ -669,7 +669,7 @@ fn get_client(config: &CondaMirrorConfig) -> miette::Result<ClientWithMiddleware
     ));
 
     client_builder = client_builder.with(RetryTransientMiddleware::new_with_policy(
-        ExponentialBackoff::builder().build_with_max_retries(3),
+        ExponentialBackoff::builder().build_with_max_retries(config.max_retries.into()),
     ));
 
     let authenticated_client = client_builder.build();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,18 @@ async fn main() -> miette::Result<()> {
         yaml_config.subdirs.clone()
     };
 
+    let max_retries = if let Some(max_retries) = yaml_config.max_retries {
+        max_retries
+    } else {
+        cli_config.max_retries
+    };
+
+    let number_of_threads_per_subdir = if let Some(number_of_threads_per_subdir) = yaml_config.number_of_threads_per_subdir {
+        number_of_threads_per_subdir
+    } else {
+        cli_config.number_of_threads_per_subdir
+    };
+
     let mode = match (yaml_config.include, yaml_config.exclude) {
         (Some(include), Some(exclude)) => MirrorMode::IncludeExclude(include, exclude),
         (Some(include), None) => MirrorMode::OnlyInclude(include),
@@ -136,6 +148,8 @@ async fn main() -> miette::Result<()> {
         destination,
         subdirs,
         mode,
+        max_retries,
+        number_of_threads_per_subdir,
         s3_config_source,
         s3_config_destination,
         s3_credentials_source,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,10 @@ async fn main() -> miette::Result<()> {
         cli_config.max_retries
     };
 
-    let number_of_threads_per_subdir = if let Some(number_of_threads_per_subdir) = yaml_config.number_of_threads_per_subdir {
-        number_of_threads_per_subdir
+    let number_of_threads = if let Some(number_of_threads) = yaml_config.number_of_threads {
+        number_of_threads
     } else {
-        cli_config.number_of_threads_per_subdir
+        cli_config.number_of_threads
     };
 
     let mode = match (yaml_config.include, yaml_config.exclude) {
@@ -149,7 +149,7 @@ async fn main() -> miette::Result<()> {
         subdirs,
         mode,
         max_retries,
-        number_of_threads_per_subdir,
+        number_of_threads,
         s3_config_source,
         s3_config_destination,
         s3_credentials_source,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,10 @@ async fn main() -> miette::Result<()> {
         cli_config.max_retries
     };
 
-    let number_of_threads = if let Some(number_of_threads) = yaml_config.number_of_threads {
-        number_of_threads
+    let max_parallel = if let Some(max_parallel) = yaml_config.max_parallel {
+        max_parallel
     } else {
-        cli_config.number_of_threads
+        cli_config.max_parallel
     };
 
     let mode = match (yaml_config.include, yaml_config.exclude) {
@@ -149,7 +149,7 @@ async fn main() -> miette::Result<()> {
         subdirs,
         mode,
         max_retries,
-        number_of_threads,
+        max_parallel,
         s3_config_source,
         s3_config_destination,
         s3_credentials_source,


### PR DESCRIPTION
# Motivation

Currently, the user does not have the ability to adjust the maximum number of threads as well as the download attempt repetition count.  The default values of 32 and 3 for these two quantities might not be optimal for some individuals environments and constraints.  This PR will expose those two elements to both the command line as well as the configuration file.

# Changes

 - Added the ability for user to adjust the maximum number of simultaneous download threads (default: 32)
 - Added the ability for the user to adjust the number of download attempts for each downloaded file (default: 3)
